### PR TITLE
Add support for cached features in iterator

### DIFF
--- a/entities/sf_data_item.py
+++ b/entities/sf_data_item.py
@@ -418,7 +418,7 @@ ORDER BY {column_name}"""
                         (
                             "The dataset is too large. Please consider using "
                             '"Execute SQL" to limit the result set. If you click '
-                            '"Proceed," only a random sample of 10 thousand rows '
+                            '"Proceed," only a random sample of 50 thousand rows '
                             "will be loaded."
                         ),
                     )

--- a/helpers/data_base.py
+++ b/helpers/data_base.py
@@ -438,7 +438,7 @@ def get_geo_column_type(
 
 def check_table_exceeds_size(
     context_information: dict,
-    limit_size: int = 10000,
+    limit_size: int = 50000,
 ) -> bool:
     """
     Checks if the number of rows in a specified table exceeds a given size limit.

--- a/helpers/mappings.py
+++ b/helpers/mappings.py
@@ -26,7 +26,7 @@ mapping_snowflake_qgis_type = {
     "NUMBER": QVariant.Double,
     "STRING": QVariant.String,
     "Date": QVariant.Date,
-    "bool": QVariant.Bool,
+    "BOOL": QVariant.Bool,
     "JSON": QVariant.String,
     "TEXT": QVariant.String,
     "ARRAY": QVariant.List,
@@ -38,4 +38,31 @@ mapping_snowflake_qgis_type = {
     "TIMESTAMP_NTZ": QVariant.DateTime,
     "TIMESTAMP_TZ": QVariant.DateTime,
     "VARIANT": QVariant.String,
+}
+
+
+SNOWFLAKE_METADATA_TYPE_CODE_DICT = {
+    0: {"name": "FIXED", "qvariant_type": QVariant.Double},  # NUMBER/INT
+    1: {"name": "REAL", "qvariant_type": QVariant.Double},  # REAL
+    2: {"name": "TEXT", "qvariant_type": QVariant.String},  # VARCHAR/STRING
+    3: {"name": "DATE", "qvariant_type": QVariant.Date},  # DATE
+    4: {"name": "TIMESTAMP", "qvariant_type": QVariant.DateTime},  # TIMESTAMP
+    5: {"name": "VARIANT", "qvariant_type": QVariant.String},  # VARIANT
+    6: {
+        "name": "TIMESTAMP_LTZ",
+        "qvariant_type": QVariant.DateTime,
+    },  # TIMESTAMP_LTZ
+    7: {"name": "TIMESTAMP_TZ", "qvariant_type": QVariant.DateTime},  # TIMESTAMP_TZ
+    8: {
+        "name": "TIMESTAMP_NTZ",
+        "qvariant_type": QVariant.DateTime,
+    },  # TIMESTAMP_NTZ
+    9: {"name": "OBJECT", "qvariant_type": QVariant.String},  # OBJECT
+    10: {"name": "ARRAY", "qvariant_type": QVariant.String},  # ARRAY
+    11: {"name": "BINARY", "qvariant_type": QVariant.BitArray},  # BINARY
+    12: {"name": "TIME", "qvariant_type": QVariant.Time},  # TIME
+    13: {"name": "BOOLEAN", "qvariant_type": QVariant.Bool},  # BOOLEAN
+    14: {"name": "GEOGRAPHY", "qvariant_type": QVariant.String},  # GEOGRAPHY
+    15: {"name": "GEOMETRY", "qvariant_type": QVariant.String},  # GEOMETRY
+    16: {"name": "VECTOR", "qvariant_type": QVariant.Vector2D},  # VECTOR
 }

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -263,6 +263,7 @@ def check_install_snowflake_connector_package() -> None:
         else:
             prefixPath = sys.exec_prefix
             python3_path = os.path.join(prefixPath, "bin", "python3")
+        subprocess.call([python3_path, "-m", "pip", "install", "pip", "—upgrade"])
         subprocess.call(
             [
                 python3_path,

--- a/providers/sf_feature_source.py
+++ b/providers/sf_feature_source.py
@@ -31,7 +31,7 @@ class SFFeatureSource(QgsAbstractFeatureSource):
     def getFeatures(self, request) -> QgsFeatureIterator:
         from ..providers.sf_feature_iterator import SFFeatureIterator
 
-        return QgsFeatureIterator(SFFeatureIterator(self, request))
+        return QgsFeatureIterator(SFFeatureIterator(source=self, request=request))
 
     def get_provider(self):
         return self._provider

--- a/providers/sf_metadata_provider.py
+++ b/providers/sf_metadata_provider.py
@@ -20,7 +20,21 @@ class SFMetadataProvider(QgsProviderMetadata):
         :param str uri: uri to convert
         :returns: dict of components as strings
         """
-        matches = re.findall(r"(\w+)=(.*?)(?= *\w+=|$)", uri)
+        supported_keys = [
+            "connection_name",
+            "sql_query",
+            "schema_name",
+            "table_name",
+            "srid",
+            "geom_column",
+            "geometry_type",
+            "geo_column_type",
+        ]
+        matches = re.findall(
+            f"({'|'.join(supported_keys)})=(.*?) *?(?={'|'.join(supported_keys)}=|$)",
+            uri,
+            flags=re.DOTALL,
+        )
         params = {key: value for key, value in matches}
         return params
 

--- a/tasks/sf_convert_sql_query_to_layer_task.py
+++ b/tasks/sf_convert_sql_query_to_layer_task.py
@@ -10,6 +10,7 @@ from qgis.PyQt.QtCore import pyqtSignal
 
 class SFConvertSQLQueryToLayerTask(QgsTask):
     on_handle_error = pyqtSignal(str, str)
+    on_success = pyqtSignal()
 
     def __init__(
         self,
@@ -95,4 +96,7 @@ class SFConvertSQLQueryToLayerTask(QgsTask):
         Returns:
             None
         """
-        pass
+        self.on_success.emit() if result else self.on_handle_error.emit(
+            "SFConvertColumnToLayerTask failed",
+            "Running snowflake convert column to layer task did not finished.",
+        )

--- a/ui/sf_sql_query_dialog.py
+++ b/ui/sf_sql_query_dialog.py
@@ -67,6 +67,7 @@ class SFSQLQueryDialog(QDialog, FORM_CLASS_SFCS):
                 sf_convert_sql_query_to_layer_task.on_handle_error.connect(
                     self.on_handle_error
                 )
+                sf_convert_sql_query_to_layer_task.on_success.connect(self.on_success)
                 QgsApplication.taskManager().addTask(sf_convert_sql_query_to_layer_task)
         except Exception as e:
             QMessageBox.information(
@@ -74,6 +75,9 @@ class SFSQLQueryDialog(QDialog, FORM_CLASS_SFCS):
                 "SFSQLQueryDialog - Add Layer from SQL Query",
                 f"Adding Layer from SQL Query failed.\n\nExtended error information:\n{str(e)}",
             )
+
+    def on_success(self):
+        self.close()
 
     def temp_deactivated_options(self) -> None:
         self.mProgressBar.setVisible(False)


### PR DESCRIPTION
* Changed to load 50k as limit
* When plugin is installed for the first time pip module will be upgraded
* Added conversion for double values
* Request subset attributes will only be considered if there are any values in the list
* Iterator fetchs data from SF DB in 5k chunks
* Flag in provider to check if features are loaded already was added
* Fix regex to get sql query as a single argument
* Provider fields are now ordered by name and type to get the same order
* Fix attributes tables for sql queries
* Add mapping  constant for sf description cursor types
* Add support for sql query dialog window to close when finished sucessfully