### PR TITLE
Add support for H3 colums in sql query dialog

### DIFF
--- a/entities/sf_data_item.py
+++ b/entities/sf_data_item.py
@@ -182,7 +182,7 @@ class SFDataItem(QgsDataItem):
         Creates schema items and appends them to the provided children list.
 
         This method iterates over features obtained from a schema iterator and creates
-        data items based on the feature attributes. It handles naming conflicts by 
+        data items based on the feature attributes. It handles naming conflicts by
         appending column names to the item names if necessary.
 
         Args:
@@ -191,12 +191,8 @@ class SFDataItem(QgsDataItem):
         Returns:
             None
         """
-        auth_information = get_authentification_information(self.settings, self.connection_name)
-        sf_data_provider = SFDataProvider(auth_information)
-        columns = get_table_geo_columns(
-            sf_data_provider, self.connection_name, self.clean_name
-        )
-        columns.sort(key = lambda x: x.attribute(0))
+        columns = get_table_geo_columns(self.connection_name, self.clean_name)
+        columns.sort(key=lambda x: x.attribute(0))
 
         children_item_type = "table"
 
@@ -277,11 +273,15 @@ class SFDataItem(QgsDataItem):
         )
 
         for feat in feature_iterator:
-            is_geo_column = (table_data_item.geom_column == feat.attribute(0))
-            if feat.attribute(1) in [
-                "GEOMETRY",
-                "GEOGRAPHY",
-            ] and not is_geo_column:
+            is_geo_column = table_data_item.geom_column == feat.attribute(0)
+            if (
+                feat.attribute(1)
+                in [
+                    "GEOMETRY",
+                    "GEOGRAPHY",
+                ]
+                and not is_geo_column
+            ):
                 continue
             item = self._create_data_item(
                 name=feat.attribute(0),
@@ -293,7 +293,9 @@ class SFDataItem(QgsDataItem):
             children.append(item)
         feature_iterator.close()
 
-    def get_field_type_svg_name(self, field_type: str, field_pression: int, is_geo_column: bool) -> str:
+    def get_field_type_svg_name(
+        self, field_type: str, field_pression: int, is_geo_column: bool
+    ) -> str:
         snowflake_types = {
             "ARRAY": "array",
             "BINARY": "binary",
@@ -425,7 +427,9 @@ ORDER BY {column_name}"""
                     "geom_type": self.geom_type,
                 }
 
-                limit_size = limit_size_for_table(context_information=context_information)
+                limit_size = limit_size_for_table(
+                    context_information=context_information
+                )
                 table_exceeds_size = check_table_exceeds_size(
                     context_information=context_information,
                 )

--- a/enums/snowflake_metadata_type.py
+++ b/enums/snowflake_metadata_type.py
@@ -1,0 +1,44 @@
+from enum import Enum
+
+
+class SnowflakeMetadataType(Enum):
+    """
+    Enum representing different Snowflake metadata types.
+
+    Attributes:
+        FIXED (int): Represents a fixed-point number.
+        REAL (int): Represents a floating-point number.
+        TEXT (int): Represents a text string.
+        DATE (int): Represents a date.
+        TIMESTAMP (int): Represents a timestamp.
+        VARIANT (int): Represents a variant type.
+        TIMESTAMP_LTZ (int): Represents a timestamp with local time zone.
+        TIMESTAMP_TZ (int): Represents a timestamp with time zone.
+        TIMESTAMP_NTZ (int): Represents a timestamp with no time zone.
+        OBJECT (int): Represents an object type.
+        ARRAY (int): Represents an array type.
+        BINARY (int): Represents binary data.
+        TIME (int): Represents a time.
+        BOOLEAN (int): Represents a boolean value.
+        GEOGRAPHY (int): Represents a geography type.
+        GEOMETRY (int): Represents a geometry type.
+        VECTOR (int): Represents a vector type.
+    """
+
+    FIXED = 0
+    REAL = 1
+    TEXT = 2
+    DATE = 3
+    TIMESTAMP = 4
+    VARIANT = 5
+    TIMESTAMP_LTZ = 6
+    TIMESTAMP_TZ = 7
+    TIMESTAMP_NTZ = 8
+    OBJECT = 9
+    ARRAY = 10
+    BINARY = 11
+    TIME = 12
+    BOOLEAN = 13
+    GEOGRAPHY = 14
+    GEOMETRY = 15
+    VECTOR = 16

--- a/helpers/mappings.py
+++ b/helpers/mappings.py
@@ -1,6 +1,8 @@
 from qgis.core import QgsWkbTypes
 from qgis.PyQt.QtCore import QVariant
 
+from ..enums.snowflake_metadata_type import SnowflakeMetadataType
+
 mapping_snowflake_qgis_geometry = {
     "LINESTRING": QgsWkbTypes.LineString,
     "MULTILINESTRING": QgsWkbTypes.MultiLineString,
@@ -42,27 +44,72 @@ mapping_snowflake_qgis_type = {
 
 
 SNOWFLAKE_METADATA_TYPE_CODE_DICT = {
-    0: {"name": "FIXED", "qvariant_type": QVariant.Double},  # NUMBER/INT
-    1: {"name": "REAL", "qvariant_type": QVariant.Double},  # REAL
-    2: {"name": "TEXT", "qvariant_type": QVariant.String},  # VARCHAR/STRING
-    3: {"name": "DATE", "qvariant_type": QVariant.Date},  # DATE
-    4: {"name": "TIMESTAMP", "qvariant_type": QVariant.DateTime},  # TIMESTAMP
-    5: {"name": "VARIANT", "qvariant_type": QVariant.String},  # VARIANT
-    6: {
-        "name": "TIMESTAMP_LTZ",
+    SnowflakeMetadataType.FIXED.value: {
+        "name": SnowflakeMetadataType.FIXED.name,
+        "qvariant_type": QVariant.Double,
+    },  # NUMBER/INT
+    SnowflakeMetadataType.REAL.value: {
+        "name": SnowflakeMetadataType.REAL.name,
+        "qvariant_type": QVariant.Double,
+    },  # REAL
+    SnowflakeMetadataType.TEXT.value: {
+        "name": SnowflakeMetadataType.TEXT.name,
+        "qvariant_type": QVariant.String,
+    },  # VARCHAR/STRING
+    SnowflakeMetadataType.DATE.value: {
+        "name": SnowflakeMetadataType.DATE.name,
+        "qvariant_type": QVariant.Date,
+    },  # DATE
+    SnowflakeMetadataType.TIMESTAMP.value: {
+        "name": SnowflakeMetadataType.TIMESTAMP.name,
+        "qvariant_type": QVariant.DateTime,
+    },  # TIMESTAMP
+    SnowflakeMetadataType.VARIANT.value: {
+        "name": SnowflakeMetadataType.VARIANT.name,
+        "qvariant_type": QVariant.String,
+    },  # VARIANT
+    SnowflakeMetadataType.TIMESTAMP_LTZ.value: {
+        "name": SnowflakeMetadataType.TIMESTAMP_LTZ.name,
         "qvariant_type": QVariant.DateTime,
     },  # TIMESTAMP_LTZ
-    7: {"name": "TIMESTAMP_TZ", "qvariant_type": QVariant.DateTime},  # TIMESTAMP_TZ
-    8: {
-        "name": "TIMESTAMP_NTZ",
+    SnowflakeMetadataType.TIMESTAMP_TZ.value: {
+        "name": SnowflakeMetadataType.TIMESTAMP_TZ.name,
+        "qvariant_type": QVariant.DateTime,
+    },  # TIMESTAMP_TZ
+    SnowflakeMetadataType.TIMESTAMP_NTZ.value: {
+        "name": SnowflakeMetadataType.TIMESTAMP_NTZ.name,
         "qvariant_type": QVariant.DateTime,
     },  # TIMESTAMP_NTZ
-    9: {"name": "OBJECT", "qvariant_type": QVariant.String},  # OBJECT
-    10: {"name": "ARRAY", "qvariant_type": QVariant.String},  # ARRAY
-    11: {"name": "BINARY", "qvariant_type": QVariant.BitArray},  # BINARY
-    12: {"name": "TIME", "qvariant_type": QVariant.Time},  # TIME
-    13: {"name": "BOOLEAN", "qvariant_type": QVariant.Bool},  # BOOLEAN
-    14: {"name": "GEOGRAPHY", "qvariant_type": QVariant.String},  # GEOGRAPHY
-    15: {"name": "GEOMETRY", "qvariant_type": QVariant.String},  # GEOMETRY
-    16: {"name": "VECTOR", "qvariant_type": QVariant.Vector2D},  # VECTOR
+    SnowflakeMetadataType.OBJECT.value: {
+        "name": SnowflakeMetadataType.OBJECT.name,
+        "qvariant_type": QVariant.String,
+    },  # OBJECT
+    SnowflakeMetadataType.ARRAY.value: {
+        "name": SnowflakeMetadataType.ARRAY.name,
+        "qvariant_type": QVariant.String,
+    },  # ARRAY
+    SnowflakeMetadataType.BINARY.value: {
+        "name": SnowflakeMetadataType.BINARY.name,
+        "qvariant_type": QVariant.BitArray,
+    },  # BINARY
+    SnowflakeMetadataType.TIME.value: {
+        "name": SnowflakeMetadataType.TIME.name,
+        "qvariant_type": QVariant.Time,
+    },  # TIME
+    SnowflakeMetadataType.BOOLEAN.value: {
+        "name": SnowflakeMetadataType.BOOLEAN.name,
+        "qvariant_type": QVariant.Bool,
+    },  # BOOLEAN
+    SnowflakeMetadataType.GEOGRAPHY.value: {
+        "name": SnowflakeMetadataType.GEOGRAPHY.name,
+        "qvariant_type": QVariant.String,
+    },  # GEOGRAPHY
+    SnowflakeMetadataType.GEOMETRY.value: {
+        "name": SnowflakeMetadataType.GEOMETRY.name,
+        "qvariant_type": QVariant.String,
+    },  # GEOMETRY
+    SnowflakeMetadataType.VECTOR.value: {
+        "name": SnowflakeMetadataType.VECTOR.name,
+        "qvariant_type": QVariant.Vector2D,
+    },  # VECTOR
 }

--- a/tasks/sf_convert_sql_query_to_layer_task.py
+++ b/tasks/sf_convert_sql_query_to_layer_task.py
@@ -27,6 +27,7 @@ class SFConvertSQLQueryToLayerTask(QgsTask):
                 else ""
             )
             self.geo_column_name = context_information["geo_column_name"]
+            self.geo_column_type_is_h3 = context_information["geo_column_type_is_h3"]
 
             self.query = query
             self.layer_name = layer_name
@@ -48,18 +49,30 @@ class SFConvertSQLQueryToLayerTask(QgsTask):
             bool: True if the task is executed successfully, False otherwise.
         """
         try:
-            geo_column_type = get_geo_column_type_from_query(
-                query=self.query,
-                context_information=self.context_information,
+            geo_column_type = (
+                "NUMBER"
+                if self.geo_column_type_is_h3
+                else get_geo_column_type_from_query(
+                    query=self.query,
+                    context_information=self.context_information,
+                )
             )
-            srid = get_srid_from_sql_query_geo_column(
-                query=self.query,
-                context_information=self.context_information,
-            ) if geo_column_type == "GEOMETRY" else 4326
-            geo_type_list = get_type_from_query_geo_column(
-                query=self.query,
-                context_information=self.context_information,
-            ) if geo_column_type != "NUMBER" else ["POLYGON"]
+            srid = (
+                get_srid_from_sql_query_geo_column(
+                    query=self.query,
+                    context_information=self.context_information,
+                )
+                if geo_column_type == "GEOMETRY"
+                else 4326
+            )
+            geo_type_list = (
+                get_type_from_query_geo_column(
+                    query=self.query,
+                    context_information=self.context_information,
+                )
+                if geo_column_type != "NUMBER"
+                else ["POLYGON"]
+            )
             for geo_type in geo_type_list:
                 uri = (
                     f"connection_name={self.connection_name} "

--- a/ui/sf_sql_query_dialog.ui
+++ b/ui/sf_sql_query_dialog.ui
@@ -119,7 +119,7 @@
          <string>Column that contains the geometry.</string>
         </property>
         <property name="text">
-         <string>Geometry column</string>
+         <string>Geometry/H3 column</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
* Refactored get_table_geo_columns method
* Added enum for snowflake metadata type codes
* Added missing documentation
* Added support for checking H3 columns in executed query
* Updated mappings to use enum
* Updated sql query to layer task to support H3 column
* Updated sql query execution dialog to display H3 columns in dropdown menu for selection
* Updated sql query execution dialog's dropbox text to say it also supports H3 columns