### PR TITLE
Fix for snowflake connector in python 3.9.5

### DIFF
--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -272,12 +272,13 @@ def check_install_package(package_name) -> None:
                 "-m",
                 "pip",
                 "install",
-                package_name + "[secure-local-storage]",
+                package_name,
             ]
         )
         subprocess.call(
             [python3_path, "-m", "pip", "install", "pyopenssl", "--upgrade"]
         )
+
 
 def check_install_snowflake_connector_package() -> None:
     """
@@ -289,6 +290,7 @@ def check_install_snowflake_connector_package() -> None:
         subprocess.CalledProcessError: If the pip installation commands fail.
     """
     check_install_package("snowflake-connector-python")
+
 
 def check_install_h3_package() -> None:
     """

--- a/metadata.txt
+++ b/metadata.txt
@@ -7,7 +7,7 @@ name=Snowflake Connector for QGIS
 qgisMinimumVersion=3.34.1
 qgisMaximumVersion=3.99
 description=This package includes the Snowflake Connector for QGIS.
-version=1.0.1
+version=1.0.2
 author=Snowflake Inc.
 email=erick.cuberojimenez@snowflake.com
 


### PR DESCRIPTION
* Increased metadata version
* Snowflake connector is no longer using the compatible version for secure-local-storage