### PR TITLE
Fix for invalid string for h3_is_valid_cell

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -7,7 +7,7 @@ name=Snowflake Connector for QGIS
 qgisMinimumVersion=3.34.1
 qgisMaximumVersion=3.99
 description=This package includes the Snowflake Connector for QGIS.
-version=1.0.2
+version=1.0.3
 author=Snowflake Inc.
 email=erick.cuberojimenez@snowflake.com
 


### PR DESCRIPTION
* Currently the h3_is_valid_cell function with certain strings returns an error where it should not. A catch was added to handle this unwanted behaviour