### PR TITLE
Fix for H3 column with no alias in query

### DIFF
--- a/providers/sf_vector_data_provider.py
+++ b/providers/sf_vector_data_provider.py
@@ -443,7 +443,7 @@ class SFH3VectorDataProvider(SFVectorDataProvider):
         flags=QgsDataProvider.ReadFlags(),
     ):
         super().__init__(uri, providerOptions, flags)
-        query = f'SELECT H3_IS_VALID_CELL("{self._column_geom}") FROM {self._from_clause} WHERE {self._column_geom} IS NOT NULL LIMIT 1'
+        query = f'SELECT H3_IS_VALID_CELL("{self._column_geom}") FROM {self._from_clause} WHERE "{self._column_geom}" IS NOT NULL LIMIT 1'
 
         cur = self.connection_manager.execute_query(
             connection_name=self._connection_name,


### PR DESCRIPTION
* Query in SFH3VectorDataProvider did not enclosed geo/h3 column in double quotes