### PR TITLE
Add support for H3 items in browser panel

### DIFF
--- a/helpers/data_base.py
+++ b/helpers/data_base.py
@@ -66,7 +66,7 @@ def filter_geo_columns(
             geo_columns.append(feat)
 
         if (
-            feat.attribute("DATA_TYPE") == ["NUMBER", "TEXT"]
+            feat.attribute("DATA_TYPE") in ["NUMBER", "TEXT"]
             and feat.attribute("COMMENT")
             and "h3" in feat.attribute("COMMENT").lower()
         ):

--- a/providers/sf_vector_data_provider.py
+++ b/providers/sf_vector_data_provider.py
@@ -93,6 +93,7 @@ class SFVectorDataProvider(QgsVectorDataProvider):
             self._is_limited_unordered = check_from_clause_exceeds_size(
                 from_clause=self._from_clause,
                 context_information=self._context_information,
+                limit_size=limit_size_for_type(self._geo_column_type),
             )
 
         self.get_geometry_column()
@@ -455,11 +456,14 @@ class SFH3VectorDataProvider(SFVectorDataProvider):
 
     def featureCount(self) -> int:
         """returns the number of entities in the table"""
-
         if not self._feature_count:
             if not self._is_valid:
                 self._feature_count = 0
             else:
+                if self._is_limited_unordered:
+                    self._feature_count = limit_size_for_type(self._geo_column_type)
+                    return self._feature_count
+
                 query = f"SELECT COUNT(*) FROM {self._from_clause}"
                 query += f' WHERE H3_IS_VALID_CELL("{self._column_geom}")'
                 if self.subsetString():


### PR DESCRIPTION
* H3 items are populated when the comment contains 'h3' (Workaround), the column type is text or number, and the helper function H3_IS_VALID_CELL returns true.